### PR TITLE
arxiv search api

### DIFF
--- a/src/main/java/capstone/paperhub_01/controller/external/ArxivProxyController.java
+++ b/src/main/java/capstone/paperhub_01/controller/external/ArxivProxyController.java
@@ -1,0 +1,44 @@
+package capstone.paperhub_01.controller.external;
+
+import capstone.paperhub_01.controller.external.response.ArxivPaperResp;
+import capstone.paperhub_01.service.ArxivService;
+import capstone.paperhub_01.util.ApiResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/arxiv")
+@RequiredArgsConstructor
+public class ArxivProxyController {
+
+    private final ArxivService arxivService;
+
+    @GetMapping("/search")
+    public ResponseEntity<ApiResult<List<ArxivPaperResp>>> search(
+            @RequestParam("query") String query,
+            @RequestParam(value = "start", defaultValue = "0") int start,
+            @RequestParam(value = "maxResults", defaultValue = "10") int maxResults
+    ) {
+        try {
+            return ResponseEntity.ok(ApiResult.success(arxivService.search(query, start, maxResults)));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity
+                    .badRequest()
+                    .body(ApiResult.error(e.getMessage(), HttpStatus.BAD_REQUEST.value()));
+        } catch (Exception e) {
+            log.error("Failed to fetch arXiv search results", e);
+            return ResponseEntity
+                    .status(HttpStatus.BAD_GATEWAY)
+                    .body(ApiResult.error("arXiv 데이터를 가져오지 못했습니다.", HttpStatus.BAD_GATEWAY.value()));
+        }
+    }
+}

--- a/src/main/java/capstone/paperhub_01/controller/external/response/ArxivPaperResp.java
+++ b/src/main/java/capstone/paperhub_01/controller/external/response/ArxivPaperResp.java
@@ -1,0 +1,31 @@
+package capstone.paperhub_01.controller.external.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ArxivPaperResp {
+    private String id;
+    private String title;
+    private String summary;
+    private List<String> authors;
+    private String pdfLink;
+    private String published;
+    private List<String> categories;
+
+    public List<String> getAuthors() {
+        return authors == null ? Collections.emptyList() : authors;
+    }
+
+    public List<String> getCategories() {
+        return categories == null ? Collections.emptyList() : categories;
+    }
+}

--- a/src/main/java/capstone/paperhub_01/service/ArxivService.java
+++ b/src/main/java/capstone/paperhub_01/service/ArxivService.java
@@ -1,0 +1,185 @@
+package capstone.paperhub_01.service;
+
+import capstone.paperhub_01.controller.external.response.ArxivPaperResp;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import java.io.StringReader;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+@Slf4j
+@Service
+public class ArxivService {
+
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(8);
+    private static final int MAX_ALLOWED_RESULTS = 50;
+    private static final String USER_AGENT = "PaperHub/1.0 (+https://paperhub.local)";
+
+    private final WebClient webClient = WebClient.builder()
+            .baseUrl("https://export.arxiv.org")
+            .defaultHeader(HttpHeaders.USER_AGENT, USER_AGENT)
+            .build();
+
+    public List<ArxivPaperResp> search(String keyword, int start, int maxResults) {
+        if (!StringUtils.hasText(keyword)) {
+            throw new IllegalArgumentException("검색어가 필요합니다.");
+        }
+
+        int safeStart = Math.max(0, start);
+        int safeMaxResults = Math.min(Math.max(1, maxResults), MAX_ALLOWED_RESULTS);
+        String trimmed = keyword.trim();
+
+        String xml = webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/api/query")
+                        .queryParam("search_query", "all:" + trimmed)
+                        .queryParam("start", safeStart)
+                        .queryParam("max_results", safeMaxResults)
+                        .build())
+                .accept(MediaType.APPLICATION_ATOM_XML)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block(REQUEST_TIMEOUT);
+
+        return parseResponse(xml);
+    }
+
+    private List<ArxivPaperResp> parseResponse(String xml) {
+        if (!StringUtils.hasText(xml)) {
+            return Collections.emptyList();
+        }
+
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document doc = builder.parse(new InputSource(new StringReader(xml)));
+            NodeList entries = doc.getElementsByTagName("entry");
+
+            List<ArxivPaperResp> papers = new ArrayList<>();
+            for (int i = 0; i < entries.getLength(); i++) {
+                Node node = entries.item(i);
+                if (!(node instanceof Element entry)) {
+                    continue;
+                }
+
+                String id = textContent(entry, "id");
+                String title = textContent(entry, "title");
+                String summary = textContent(entry, "summary");
+                String published = textContent(entry, "published");
+                List<String> authors = extractAuthors(entry);
+                List<String> categories = extractCategories(entry);
+                String pdfLink = extractPdfLink(entry, id);
+
+                papers.add(ArxivPaperResp.builder()
+                        .id(safeString(id))
+                        .title(safeString(title))
+                        .summary(safeString(summary))
+                        .authors(authors)
+                        .pdfLink(pdfLink)
+                        .published(safeString(published))
+                        .categories(categories)
+                        .build());
+            }
+
+            return papers;
+        } catch (Exception e) {
+            log.error("Failed to parse arXiv response", e);
+            throw new IllegalStateException("arXiv 응답 파싱에 실패했습니다.", e);
+        }
+    }
+
+    private String textContent(Element parent, String tag) {
+        NodeList nodes = parent.getElementsByTagName(tag);
+        if (nodes.getLength() == 0) {
+            return "";
+        }
+        Node node = nodes.item(0);
+        return node != null ? node.getTextContent().trim() : "";
+    }
+
+    private List<String> extractAuthors(Element entry) {
+        NodeList authorNodes = entry.getElementsByTagName("author");
+        if (authorNodes.getLength() == 0) {
+            return Collections.emptyList();
+        }
+        List<String> authors = new ArrayList<>();
+        for (int i = 0; i < authorNodes.getLength(); i++) {
+            Node node = authorNodes.item(i);
+            if (!(node instanceof Element authorEl)) {
+                continue;
+            }
+            String name = textContent(authorEl, "name");
+            if (StringUtils.hasText(name)) {
+                authors.add(name);
+            }
+        }
+        return authors;
+    }
+
+    private List<String> extractCategories(Element entry) {
+        NodeList categoryNodes = entry.getElementsByTagName("category");
+        if (categoryNodes.getLength() == 0) {
+            return Collections.emptyList();
+        }
+
+        List<String> categories = new ArrayList<>();
+        for (int i = 0; i < categoryNodes.getLength(); i++) {
+            Node node = categoryNodes.item(i);
+            if (node instanceof Element categoryEl) {
+                String term = categoryEl.getAttribute("term");
+                if (StringUtils.hasText(term)) {
+                    categories.add(term);
+                }
+            }
+        }
+        return categories;
+    }
+
+    private String extractPdfLink(Element entry, String idFallback) {
+        NodeList linkNodes = entry.getElementsByTagName("link");
+        for (int i = 0; i < linkNodes.getLength(); i++) {
+            Node node = linkNodes.item(i);
+            if (!(node instanceof Element linkEl)) {
+                continue;
+            }
+            String title = linkEl.getAttribute("title");
+            String type = linkEl.getAttribute("type");
+            if ("pdf".equalsIgnoreCase(title) || "application/pdf".equalsIgnoreCase(type)) {
+                String href = linkEl.getAttribute("href");
+                if (StringUtils.hasText(href)) {
+                    return href;
+                }
+            }
+        }
+
+        if (StringUtils.hasText(idFallback) && idFallback.contains("/abs/")) {
+            return idFallback.replace("/abs/", "/pdf/") + ".pdf";
+        }
+        return "";
+    }
+
+    private String safeString(String value) {
+        return value == null ? "" : value;
+    }
+}


### PR DESCRIPTION
### 엔드포인트

- GET /api/arxiv/search

### 요청 파라미터

- query (필수, string): 검색 키워드. 비어있거나 공백뿐이면 400 Bad Request.
- start (선택, int, 기본값 0): 결과 시작 인덱스. 0 미만이면 0으로 보정.
- maxResults (선택, int, 기본값 10): 한 번에 가져올 개수. 1 미만이면 1, 50 초과면 50으로 보정.

###성공 응답 (200)

바디 타입: ApiResult<List<ArxivPaperResp>>
JSON 구조 예시:
```
{
  "success": true,
  "data": [
    {
      "id": "https://arxiv.org/abs/1706.03762",
      "title": "Attention Is All You Need",
      "summary": "We propose the Transformer, ...",
      "authors": ["Ashish Vaswani", "Noam Shazeer"],
      "pdfLink": "https://arxiv.org/pdf/1706.03762.pdf",
      "published": "2017-06-01T00:00:00Z",
      "categories": ["cs.CL", "cs.LG"]
    }
  ],
  "error": null
}
```
- ArxivPaperResp 필드:
- - id: arXiv 논문 ID(주로 abs 링크)
- - title: 제목
- - summary: 초록 텍스트
- - authors: 저자명 리스트 (null 방지, 항상 배열; 없으면 [])
- - pdfLink: PDF 다운로드 링크 (XML에 pdf 링크 없으면 id 기준으로 /abs/ → /pdf/ 변환 후 .pdf 붙여 생성)
- - published: 발행일 문자열
- - categories: 카테고리(term) 리스트 (없으면 [])
- 모든 문자열 필드는 내부적으로 null이면 빈 문자열 ""로 보정.

### 에러 응답

- 잘못된 요청 (예: query 누락/공백): 
- - HTTP 상태: 400 Bad Request
- - 바디: ApiResult.error(message, 400)
- - 예: {"success":false,"data":null,"error":{"message":"검색어가 필요합니다.","status":400}}
- 외부 arXiv API 오류·타임아웃·파싱 실패 등:
- - HTTP 상태: 502 Bad Gateway
- - 바디: {"success":false,"data":null,"error":{"message":"arXiv 데이터를 가져오지 못했습니다.","status":502}}
